### PR TITLE
Move out some functionality to basic engine and add a limited routing engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,26 @@ and one that doesn't and just blindly replies with the consecutive response
 
 ## Built-in engines
 
+### The `basic` and `silly-rest` engine
+
+* the `basic` engine is a minimal engine with some basic functionality for
+loading scenarios / blueprints. It is supposed to be extended by other engines.
+
+* the `silly-rest` engine is a "RESTful" engine that can be used to create
+trivial routing based on request method and request URL
+
+For a simple example to get you started, run:
+	katt-player -e silly-rest silly-rest-examples.apib
+
+Then if you open your browser to the URL `http://localhost:1337/examples` you
+can expect to find a mockup of a "RESTful" app that conforms to the API defined
+in the silly-rest-examples.apib specification.
+
+The silly-rest engine doesn't have any knowledge of mediatypes, which is the
+main reason why it's silly. It also doesn't do any magic for you at the moment.
+
+### The `linear-check` and `linear` engines
+
 These two engines will look at
 
 * the request's cookie `katt_scenario` to decide which scenario to focus on

--- a/bin/cli.coffee
+++ b/bin/cli.coffee
@@ -56,7 +56,7 @@ parseArgs = (args) ->
     type: 'int'
 
   parser.addArgument ['--hostname'],
-    help: 'Server hostname / IP address. (%(defaultValue)d)'
+    help: 'Server hostname / IP address. (%(defaultValue)s)'
     defaultValue: '0.0.0.0'
     type: 'string'
 

--- a/silly-rest-examples.apib
+++ b/silly-rest-examples.apib
@@ -1,0 +1,60 @@
+--- A silly example of a blueprint ---
+
+GET /examples
+> Accept: text/html
+< 200
+< Content-Type: text/html; charset=UTF-8
+<<<
+<!doctype html>
+<pre>
+<h1>Here are some silly <a href=/examples>examples</h1>
+<a href=/examples/1.html>examples/1.html
+<a href=/examples/1.json>examples/1.json
+<a href=/examples/nothing-is-here.html>broken link</a>
+
+<img style=width:100px id=cat src=http://cdn.grumpycats.com/wp-content/uploads/2013/08/08.28.2013-2.jpg>
+<script src=data:text/javascript;base64,Zm9yKGk9OSxjPWRvY3VtZW50LmdldEVsZW1lbnRCeUlkKCdjYXQnKTtpLS0+MDspZG9jdW1lbnQuYm9keS5hcHBlbmRDaGlsZChjLmNsb25lTm9kZShpKSk=></script>
+
+<form method=post action=/examples>
+<input name=name>
+<button>OK
+</form>
+>>>
+
+POST /examples
+< 404
+< Content-Type: text/html
+Thank you. I don't have any memory. But thanks for trying.
+
+GET /examples/1.html
+> Accept: *
+< 200
+< Content-Type: text/html
+<<<
+<h1>Hello!</h1>
+<p>I am an example.</p>
+>>>
+
+GET /examples/1.json
+> Accept: *
+< 200
+< Content-Type: application/json
+{
+    "message": "Hello, I am an example."
+}
+
+GET /examples/random
+< 200
+hello
+
+GET /examples/random
+< 200
+hi
+
+GET /examples/random
+< 200
+aloha
+
+GET /examples/random
+< 200
+hej

--- a/src/engines/basic.coffee
+++ b/src/engines/basic.coffee
@@ -1,0 +1,107 @@
+###
+   Copyright 2013 Klarna AB
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+###
+
+fs = require 'fs'
+path = require 'path'
+url = require 'url'
+glob = require 'glob'
+_ = require 'lodash'
+katt = require 'katt-js'
+{
+  isJsonCT
+  normalizeHeaders
+  parseHost
+} = katt.utils
+callbacks = katt.callbacks
+
+
+GLOB_OPTIONS =
+  nosort: true
+  stat: false
+
+
+# A trivial engine without any magic apart from basic routing possibilities.
+module.exports = class BasicEngine
+
+  constructor: ({scenarios, options}) ->
+    return new BasicEngine({scenarios, options})  unless this instanceof BasicEngine
+    options or= {}
+    @options = _.merge options, {
+      hooks: {}
+    }
+    @scenariosByFilename = {}
+    @loadScenarios scenarios
+
+  eachBlueprint: (fun = ((bp) -> bp)) ->
+    fun(blueprint, filename)  for filename, {blueprint} of @scenariosByFilename
+
+  loadScenario: (filename) ->
+    try
+      blueprint = katt.readScenario filename
+      for transaction in blueprint.transactions
+        for reqres in [transaction.request, transaction.response]
+          continue  unless reqres.body?
+          try
+            reqres.body = callbacks.parse {
+              headers: normalizeHeaders reqres.headers
+              body: reqres.body
+            }
+          catch e
+            console.log 'loadScenarios error while parsing ', reqres
+            throw new Error "Unable to parse blueprint"
+    catch e
+      throw new Error "Unable to find/parse blueprint file #{filename}\n#{e}"
+    @scenariosByFilename[filename] = {
+      filename
+      blueprint
+    }
+
+
+  loadScenarios: (scenarios) ->
+    scenarios = [scenarios]  unless _.isArray scenarios
+    for scenario in scenarios
+      continue  unless fs.existsSync scenario
+      scenario = path.normalize scenario
+
+      if fs.statSync(scenario).isDirectory()
+        apibs = glob.sync "#{scenario}/**/*.apib", GLOB_OPTIONS
+        @loadScenarios apibs
+      else if fs.statSync(scenario).isFile()
+        @loadScenario scenario
+
+
+  callHook: (name, req, res, next) ->
+    if @options.hooks[name]?
+      @options.hooks[name] req, res, next
+    else
+      next()  if next?
+
+
+  sendError: (res, statusCode, error) ->
+    res.setHeader 'Content-Type', 'text/plain'
+    res.setHeader 'X-KATT-Error', encodeURIComponent error.split('\n').shift()
+    res.send statusCode, error
+
+  sendResponse: (req, res, next) ->
+    @callHook 'preSend', req, res, () =>
+      res.body = JSON.stringify(res.body, null, 2)  if isJsonCT res.getHeader 'content-type'
+      res.send res.body
+      @callHook 'postSend', req, res, () ->
+
+
+  middleware: (req, res, next) ->
+    @sendError res, 500, 'Define a middleware unless all you want is this error'
+

--- a/src/engines/silly-rest.coffee
+++ b/src/engines/silly-rest.coffee
@@ -1,0 +1,53 @@
+###
+   Copyright 2013 Klarna AB
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+###
+
+BasicEngine = require './basic'
+
+# A naïve "RESTful" engine without any magic apart from silly routing with a
+# random response in case of many possible responses for the same route.
+module.exports = class SillyRestEngine extends BasicEngine
+
+  constructor: ({scenarios, options}) ->
+    return new SillyRestEngine({scenarios, options}) \
+      unless this instanceof SillyRestEngine
+
+    super
+    @requestToResponses = {}
+    @eachBlueprint (blueprint, filename) =>
+      for t in blueprint.transactions
+        (@requestToResponses[@hashify(t.request)] or= []).push t.response
+
+    console.log 'Silly "RESTful" routing table'
+    console.log @requestToResponses
+
+
+  hashify: (req) ->
+    [req.method, req.url].join(':')
+
+
+  middleware: (req, res, next) ->
+    possibleResponses = @requestToResponses[@hashify(req)]
+    return @sendError res, 500, 'No possible response'  unless possibleResponses
+
+    index = Math.floor(Math.random() * possibleResponses.length)
+    response = possibleResponses[index]
+    {headers, body, status} = response
+
+    res.body = body
+    res.statusCode = status
+    res.setHeader header, headerValue  for header, headerValue of headers
+    @sendResponse req, res, next
+    true

--- a/src/katt-player.coffee
+++ b/src/katt-player.coffee
@@ -52,3 +52,4 @@ exports.makeServer = (engine) ->
 exports.engines =
   'linear': require './engines/linear'
   'linear-check': require './engines/linear-check'
+  'basic': require './engines/basic'

--- a/src/katt-player.coffee
+++ b/src/katt-player.coffee
@@ -53,3 +53,4 @@ exports.engines =
   'linear': require './engines/linear'
   'linear-check': require './engines/linear-check'
   'basic': require './engines/basic'
+  'silly-rest': require './engines/silly-rest'


### PR DESCRIPTION
The linear and linear-check engines are a bit difficult to grasp and  limited in usefulness. Hence I created a couple of engines that are perhaps easier to start with and extend to your needs if your needs aren't linear. There is a basic engine with some common functionality for other engines and a silly rest engine with "support" for RESTful URL:s and not much more.
